### PR TITLE
feat(docker): personal-busybox CLI image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# Git history — not needed in build context, reduces context size
+.git
+
+# Ansible vault — NEVER include secrets in the build context
+src/group_vars/all/vault.yml
+
+# Vault password and other secret files
+.vault_pass
+*.env
+.env
+*.key
+*.pem
+*.p12
+
+# OS and editor artifacts
+.DS_Store
+**/.DS_Store
+*.swp
+*.swo
+
+# Python artifacts
+__pycache__
+*.pyc
+*.pyo
+
+# Node (in case any tooling uses it)
+node_modules

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -20,10 +20,6 @@ jobs:
       - uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: Dockerfile
-          # DL3003: cd inside a single RUN layer is intentional (layer efficiency)
-          # DL3004: sudo is required — non-root user needs sudo for pacman/AUR builds
-          # SC2015: cmd || true is intentional for optional cleanup steps
-          ignore: DL3003 DL3004 SC2015
 
   build:
     name: Build & Smoke Test

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: Dockerfile
+          config: .hadolint.yaml
 
   build:
     name: Build & Smoke Test

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,166 @@
+name: Build & Publish CLI Image
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/dotfiles-env
+
+jobs:
+  lint:
+    name: Lint Dockerfile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+
+  build:
+    name: Build & Smoke Test
+    runs-on: ubuntu-latest
+    needs: lint
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image-digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+
+      - name: Build image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          # load: true allows the smoke test to run against the local image;
+          # compatible with push on single-platform builds
+          load: true
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test
+        env:
+          IMAGE: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+        run: bash scripts/smoke-test.sh "$IMAGE"
+
+  scan:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          exit-code: 0
+
+      - name: Upload Trivy results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+
+  sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+      packages: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate SBOM with Syft
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+          artifact-name: sbom-${{ github.ref_name }}.spdx.json
+          output-file: sbom.spdx.json
+
+      - name: Upload SBOM to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: sbom.spdx.json
+
+  sign:
+    name: Sign Image
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign image with cosign (keyless)
+        env:
+          DIGEST: ${{ needs.build.outputs.image-digest }}
+        run: |
+          cosign sign --yes \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -20,7 +20,10 @@ jobs:
       - uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: Dockerfile
-          config: .hadolint.yaml
+          # DL3003: cd inside a single RUN layer is intentional (layer efficiency)
+          # DL3004: sudo is required — non-root user needs sudo for pacman/AUR builds
+          # SC2015: cmd || true is intentional for optional cleanup steps
+          ignore: DL3003 DL3004 SC2015
 
   build:
     name: Build & Smoke Test

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,7 @@
+ignore:
+  # sudo is required: non-root user (frank) must call sudo for pacman/system tasks;
+  # this is the standard pattern for AUR builds where makepkg cannot run as root.
+  - DL3004
+  # cmd 2>/dev/null || true is intentional — allows optional cleanup steps to fail
+  # gracefully without aborting the build (e.g. removing packages that may not exist).
+  - SC2015

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+FROM archlinux:base-devel
+
+ARG UID=1000
+ARG USER=frank
+
+LABEL org.opencontainers.image.source="https://github.com/frankjuniorr/dotfiles"
+LABEL org.opencontainers.image.description="Personal CLI environment — Frank's dotfiles"
+
+# Initialize pacman keyring and create non-root user (required for AUR/makepkg)
+RUN pacman-key --init && pacman-key --populate && \
+    useradd -m -u ${UID} -G wheel -s /bin/zsh ${USER} && \
+    echo "${USER} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Copy repo to the same path used by docker-compose volume mount
+COPY --chown=${USER}:${USER} . /home/${USER}/.dotfiles/
+
+USER ${USER}
+WORKDIR /home/${USER}
+
+# All provisioning in one layer so cleanup actually reduces image size
+# --mount=type=secret exposes the vault password only during this RUN step;
+# it is never written to any image layer and does not appear in docker history.
+RUN --mount=type=secret,id=vault_pass,uid=1000,target=/run/secrets/vault_pass \
+    set -eo pipefail && \
+    # Install AUR helper — build from source (avoids yay-bin's GitHub binary download, which can 502)
+    sudo pacman -Sy --noconfirm --needed git go && \
+    git clone https://aur.archlinux.org/yay.git /tmp/yay && \
+    cd /tmp/yay && makepkg -si --noconfirm && cd ~ && \
+    rm -rf /tmp/yay && \
+    \
+    # Install Ansible and Galaxy dependencies
+    sudo pacman -S --noconfirm --needed ansible && \
+    ansible-galaxy collection install community.general && \
+    ansible-galaxy install -r ~/.dotfiles/src/requirements/common.yml && \
+    \
+    # Run playbook — CLI roles only, no 1Password (vault.yml excluded via .dockerignore)
+    cd ~/.dotfiles/src && \
+    ANSIBLE_STDOUT_CALLBACK=default \
+    ansible-playbook -i hosts.ini main.yml \
+        --tags "cli" \
+        --vault-password-file /run/secrets/vault_pass \
+        -e '{"op_installed": false, "is_docker_build": true}' && \
+    \
+    # Remove Ansible and its galaxy collections (build-time only)
+    sudo pacman -Rns --noconfirm ansible ansible-core python-resolvelib 2>/dev/null || true && \
+    sudo rm -rf /usr/lib/python*/site-packages/ansible* \
+                /usr/lib/python*/site-packages/ansible_collections && \
+    \
+    # Clear all caches
+    yay -Scc --noconfirm && \
+    sudo pacman -Scc --noconfirm && \
+    go clean -cache 2>/dev/null || true && \
+    sudo rm -rf /tmp/* /root/.ansible ~/.ansible \
+                ~/.cache/pip ~/.cargo/registry 2>/dev/null || true
+
+ENTRYPOINT ["/usr/bin/tmux", "new-session", "-As", "main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.description="Personal CLI environment — Frank's
 
 # Initialize pacman keyring and create non-root user (required for AUR/makepkg)
 RUN pacman-key --init && pacman-key --populate && \
-    useradd -m -u ${UID} -G wheel -s /bin/zsh ${USER} && \
+    useradd -m -u ${UID} -G wheel -s /bin/zsh -l ${USER} && \
     echo "${USER} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # Copy repo to the same path used by docker-compose volume mount
@@ -25,7 +25,7 @@ RUN --mount=type=secret,id=vault_pass,uid=1000,target=/run/secrets/vault_pass \
     # Install AUR helper — build from source (avoids yay-bin's GitHub binary download, which can 502)
     sudo pacman -Sy --noconfirm --needed git go && \
     git clone https://aur.archlinux.org/yay.git /tmp/yay && \
-    cd /tmp/yay && makepkg -si --noconfirm && cd ~ && \
+    (cd /tmp/yay && makepkg -si --noconfirm) && \
     rm -rf /tmp/yay && \
     \
     # Install Ansible and Galaxy dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,9 @@ WORKDIR /home/${USER}
 # All provisioning in one layer so cleanup actually reduces image size
 # --mount=type=secret exposes the vault password only during this RUN step;
 # it is never written to any image layer and does not appear in docker history.
+# vault_pass is optional: vault.yml is excluded via .dockerignore so CI builds work without it.
 # hadolint ignore=DL3003,DL3004,SC2015
-RUN --mount=type=secret,id=vault_pass,uid=1000,target=/run/secrets/vault_pass \
+RUN --mount=type=secret,id=vault_pass,uid=1000,target=/run/secrets/vault_pass,required=false \
     set -eo pipefail && \
     # Install AUR helper — build from source (avoids yay-bin's GitHub binary download, which can 502)
     sudo pacman -Sy --noconfirm --needed git go && \
@@ -36,10 +37,12 @@ RUN --mount=type=secret,id=vault_pass,uid=1000,target=/run/secrets/vault_pass \
     \
     # Run playbook — CLI roles only, no 1Password (vault.yml excluded via .dockerignore)
     cd ~/.dotfiles/src && \
+    VAULT_OPT="" && \
+    if [ -f /run/secrets/vault_pass ]; then VAULT_OPT="--vault-password-file /run/secrets/vault_pass"; fi && \
     ANSIBLE_STDOUT_CALLBACK=default \
     ansible-playbook -i hosts.ini main.yml \
         --tags "cli" \
-        --vault-password-file /run/secrets/vault_pass \
+        ${VAULT_OPT} \
         -e '{"op_installed": false, "is_docker_build": true}' && \
     \
     # Remove Ansible and its galaxy collections (build-time only)

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ WORKDIR /home/${USER}
 # All provisioning in one layer so cleanup actually reduces image size
 # --mount=type=secret exposes the vault password only during this RUN step;
 # it is never written to any image layer and does not appear in docker history.
+# hadolint ignore=DL3003,DL3004,SC2015
 RUN --mount=type=secret,id=vault_pass,uid=1000,target=/run/secrets/vault_pass \
     set -eo pipefail && \
     # Install AUR helper — build from source (avoids yay-bin's GitHub binary download, which can 502)

--- a/Justfile
+++ b/Justfile
@@ -4,6 +4,10 @@ export VAULT_PASS_FILE := home_dir() + "/.config/homelab-iac/.vault_pass"
 
 ansible_cmd := "ansible-playbook -i " + quote(invocation_directory() + "/src/hosts.ini") + " --vault-password-file " + VAULT_PASS_FILE
 
+image        := "frank-env"
+registry_img := "ghcr.io/frankjuniorr/dotfiles-env"
+docker_gid   := `stat -c '%g' /var/run/docker.sock`
+
 # Instala git hooks
 install-hooks:
 	@echo "Installing git pre-commit hook..."
@@ -42,6 +46,51 @@ secrets-decrypt:
 # Apenas visualiza os segredos descriptografados no terminal
 secrets-view:
 	@ansible-vault view src/group_vars/all/vault.yml --vault-password-file {{VAULT_PASS_FILE}}
+
+############################################################################
+# DOCKER (personal-busybox)
+############################################################################
+# Build the CLI image locally (BuildKit enabled; vault password passed as a build secret)
+docker-build:
+	DOCKER_BUILDKIT=1 docker build \
+		--secret id=vault_pass,src={{VAULT_PASS_FILE}} \
+		-t {{image}} .
+
+# Force a clean rebuild from scratch (bypasses all Docker layer cache)
+docker-rebuild: docker-clean
+	DOCKER_BUILDKIT=1 docker build \
+		--no-cache \
+		--secret id=vault_pass,src={{VAULT_PASS_FILE}} \
+		-t {{image}} .
+
+# Run smoke tests (builds first if needed)
+docker-smoke: docker-build
+	@scripts/smoke-test.sh {{image}}
+
+# Start container via docker-compose with the locally built image
+docker-up-local: docker-build
+	FRANK_ENV_IMAGE={{image}} DOCKER_GID={{docker_gid}} docker compose up -d
+
+# Start container via docker-compose with the registry image (default)
+docker-up:
+	DOCKER_GID={{docker_gid}} docker compose up -d
+
+# Enter the running container (attaches to or creates tmux session)
+docker-enter:
+	docker exec -it frank-env tmux new-session -As main
+
+# Pull latest image from ghcr.io
+docker-pull:
+	docker compose pull
+
+# Stop and remove the container
+docker-down:
+	docker compose down
+
+# Remove container + local image (forces a full rebuild on next docker-build)
+docker-clean:
+	docker compose down 2>/dev/null || true
+	docker rmi {{image}} 2>/dev/null || true
 
 ############################################################################
 # UTILS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  frank-env:
+    image: ${FRANK_ENV_IMAGE:-ghcr.io/frankjuniorr/dotfiles-env:latest}
+    container_name: frank-env
+    stdin_open: true
+    tty: true
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop: [ALL]
+    group_add:
+      - "${DOCKER_GID}"
+    environment:
+      - SSH_AUTH_SOCK=/run/ssh-agent
+      - GITHUB_TOKEN=${GITHUB_TOKEN:-}
+      - TZ=America/Recife
+    volumes:
+      # SSH agent socket — 1Password sets $SSH_AUTH_SOCK automatically
+      - ${SSH_AUTH_SOCK:-/dev/null}:/run/ssh-agent:ro
+      # Kubeconfig (read-only)
+      - ${HOME}/.kube:/home/frank/.kube:ro
+      # Docker socket — DooD (Docker-out-of-Docker)
+      - /var/run/docker.sock:/var/run/docker.sock
+      # Current working directory mapped to /workspace
+      - ${PWD}:/workspace
+    working_dir: /workspace

--- a/install-env.sh
+++ b/install-env.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -e
+
+IMAGE="ghcr.io/frankjuniorr/dotfiles-env:latest"
+COMPOSE_URL="https://raw.githubusercontent.com/frankjuniorr/dotfiles/main/docker-compose.yml"
+ENV_DIR="${HOME}/.frank-env"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info()    { echo -e "${GREEN}[frank-env]${NC} $*"; }
+warn()    { echo -e "${YELLOW}[frank-env]${NC} $*"; }
+error()   { echo -e "${RED}[frank-env]${NC} $*" >&2; exit 1; }
+
+# Check dependencies
+command -v docker >/dev/null 2>&1 || error "Docker is not installed. Install it from https://docs.docker.com/get-docker/"
+command -v docker compose version >/dev/null 2>&1 || error "Docker Compose v2 is required. Update Docker Desktop or install the plugin."
+
+info "Setting up frank-env in ${ENV_DIR}"
+mkdir -p "${ENV_DIR}"
+
+# Download docker-compose.yml
+info "Downloading docker-compose.yml..."
+curl -fsSL "${COMPOSE_URL}" -o "${ENV_DIR}/docker-compose.yml"
+
+# Pull the image
+info "Pulling ${IMAGE}..."
+docker pull "${IMAGE}"
+
+# Start container
+info "Starting frank-env container..."
+cd "${ENV_DIR}" && docker compose up -d
+
+# Offer to add shell alias
+echo
+warn "Add the following alias to your shell for quick access:"
+echo
+echo "  alias fe='docker exec -it frank-env tmux new-session -As main'"
+echo
+read -r -p "Add 'fe' alias to your shell profile now? [y/N] " reply
+if [[ "${reply}" =~ ^[Yy]$ ]]; then
+    PROFILE="${HOME}/.zshrc"
+    [[ -n "${BASH_VERSION}" ]] && PROFILE="${HOME}/.bashrc"
+
+    if grep -q "alias fe=" "${PROFILE}" 2>/dev/null; then
+        warn "Alias already exists in ${PROFILE}"
+    else
+        echo "alias fe='docker exec -it frank-env tmux new-session -As main'" >> "${PROFILE}"
+        info "Alias added to ${PROFILE}. Run 'source ${PROFILE}' or open a new terminal."
+    fi
+fi
+
+echo
+info "Done! Enter your environment with:"
+echo "  docker exec -it frank-env tmux new-session -As main"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+# ── Context detection ────────────────────────────────────────────────────────
+# Inside a Docker container: run tools directly.
+# Outside: run via `docker run` against the given image.
+if [ -f /.dockerenv ]; then
+    CONTEXT="inside container"
+    run_cmd() { bash -c "$1" > /dev/null 2>&1; }
+else
+    IMAGE="${1:?Usage: smoke-test.sh <image-name>  (or run inside the container without args)}"
+    CONTEXT="docker image: ${IMAGE}"
+    # -i (interactive) so zsh sources .zshrc and ~/.local/bin is in PATH
+    run_cmd() { docker run --rm --entrypoint zsh "$IMAGE" -i -c "$1" > /dev/null 2>&1; }
+fi
+
+# ── Check helper ─────────────────────────────────────────────────────────────
+check() {
+    local name="$1" cmd="$2"
+    if run_cmd "$cmd"; then
+        echo -e "  ${GREEN}✓${NC} ${name}"
+        ((PASS++)) || true
+    else
+        echo -e "  ${RED}✗${NC} ${name}"
+        ((FAIL++)) || true
+    fi
+}
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+echo
+echo -e "${BOLD}Smoke test — ${CONTEXT}${NC}"
+echo "─────────────────────────────"
+
+echo "Shell & terminal"
+check "zsh"            "zsh --version"
+check "tmux"           "tmux -V"
+check "tmuxinator"     "tmuxinator version"
+check "starship"       "starship --version"
+
+echo "CLI tools"
+check "bat"            "bat --version"
+check "fd"             "fd --version"
+check "fzf"            "fzf --version"
+check "zoxide"         "zoxide --version"
+check "lsd"            "lsd --version"
+check "btop"           "command -v btop"
+check "just"           "just --version"
+check "atuin"          "atuin --version"
+check "navi"           "navi --version"
+check "yazi"           "yazi --version"
+check "glow"           "glow --version"
+check "ripgrep"        "rg --version"
+check "sesh"           "sesh version"
+check "onefetch"       "onefetch --version"
+
+echo "System tools"
+check "jq"             "jq --version"
+check "yq"             "yq --version"
+check "gum"            "gum --version"
+check "duf"            "duf --version"
+check "ncdu"           "ncdu --version"
+check "sshs"           "sshs --version"
+
+echo "Git"
+check "git"            "git --version"
+check "lazygit"        "lazygit --version"
+check "git-delta"      "delta --version"
+check "gh"             "gh --version"
+
+echo "Editor"
+check "neovim"         "nvim --version"
+
+echo "DevOps"
+check "docker CLI"     "docker --version"
+check "lazydocker"     "lazydocker --version"
+check "kubectl"        "kubectl version --client"
+check "kubecolor"      "command -v kubecolor"
+check "helm"           "helm version --short"
+check "k9s"            "k9s version"
+check "go"             "go version"
+check "cobra-cli"      "command -v cobra-cli"
+check "tfenv"          "tfenv --version"
+
+echo "Dotfiles"
+check "aliases symlink"   "test -L ~/.config/dotfiles/alias.sh"
+check "functions symlink" "test -L ~/.config/dotfiles/functions.sh"
+check "env symlink"       "test -L ~/.config/dotfiles/env.sh"
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo "─────────────────────────────"
+echo -e "${BOLD}Results: ${GREEN}${PASS} passed${NC}${BOLD}, ${RED}${FAIL} failed${NC}"
+echo
+
+[ "$FAIL" -eq 0 ]

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -18,8 +18,8 @@ if [ -f /.dockerenv ]; then
 else
     IMAGE="${1:?Usage: smoke-test.sh <image-name>  (or run inside the container without args)}"
     CONTEXT="docker image: ${IMAGE}"
-    # -i (interactive) so zsh sources .zshrc and ~/.local/bin is in PATH
-    run_cmd() { docker run --rm --entrypoint zsh "$IMAGE" -i -c "$1" > /dev/null 2>&1; }
+    # Source zshenv (sets ZDOTDIR) + .zshrc (sets PATH) without -i so it works without a TTY (CI)
+    run_cmd() { docker run --rm --entrypoint zsh "$IMAGE" -c ". /etc/zsh/zshenv 2>/dev/null; . \${ZDOTDIR:-\$HOME}/.zshrc 2>/dev/null; $1" > /dev/null 2>&1; }
 fi
 
 # ── Check helper ─────────────────────────────────────────────────────────────

--- a/src/group_vars/all/vars.yaml
+++ b/src/group_vars/all/vars.yaml
@@ -4,6 +4,46 @@
 primary_installation_path: "{{ ansible_facts.user_dir }}/.local/bin"
 scripts_installation_path: "{{ ansible_facts.user_dir }}/.bin"
 
+cli_roles:
+  - system-base
+  - 1password
+  - git
+  - fzf
+  - atuin
+  - bat
+  - zoxide
+  - lsd
+  - btop
+  - fetchs
+  - just
+  - fd
+  - yazi
+  - sesh
+  - navi
+  - neovim
+  - starship
+  - zsh
+  - tmux
+  - docker
+  - terraform
+  - go
+  - kubernetes
+  - dotfiles
+
+gui_roles:
+  - fonts
+  - terminal
+  - solaar
+  - funny-apps
+  - dropbox
+  - insync
+  - vscode
+  - google-chrome
+  - telegram
+  - spotify
+  - obsidian
+  - hyde
+
 default_roles:
   - system-base
   - 1password     # password manager first

--- a/src/main.yml
+++ b/src/main.yml
@@ -19,7 +19,16 @@
 
     - name: Set roles
       ansible.builtin.set_fact:
-        run_roles: "{{ ansible_run_tags != ['all'] and ansible_run_tags or default_roles }}"
+        run_roles: >-
+          {%- if 'cli' in ansible_run_tags -%}
+            {{ cli_roles }}
+          {%- elif 'gui' in ansible_run_tags -%}
+            {{ gui_roles }}
+          {%- elif ansible_run_tags != ['all'] -%}
+            {{ ansible_run_tags }}
+          {%- else -%}
+            {{ default_roles }}
+          {%- endif -%}
       tags:
         - always
 
@@ -28,6 +37,7 @@
         apply:
           tags:
             - "{{ roles_item }}"
+            - always
         name: "{{ roles_item }}"
       loop_control:
         loop_var: roles_item

--- a/src/pre_tasks/detect_1password.yaml
+++ b/src/pre_tasks/detect_1password.yaml
@@ -4,9 +4,10 @@
     cmd: which op
   changed_when: false
   failed_when: false
-  register: op_installed
+  register: op_check
+  when: op_installed is not defined
 
 - name: "1PASSWORD | Register 1Password"
   ansible.builtin.set_fact:
-    op_installed: "{{ op_installed.rc == 0 }}"
-  when: op_installed.rc == 0
+    op_installed: "{{ op_check.rc == 0 }}"
+  when: op_installed is not defined

--- a/src/roles/1password/tasks/main.yaml
+++ b/src/roles/1password/tasks/main.yaml
@@ -4,10 +4,13 @@
     path: "{{ role_path }}/tasks/{{ ansible_facts.distribution }}.yaml"
   register: system_distribution_config
   no_log: true
+  when: not (is_docker_build | default(false))
 
 - name: "System | Run Tasks: {{ ansible_facts.distribution }}"
   ansible.builtin.include_tasks: "{{ ansible_facts.distribution }}.yaml"
-  when: system_distribution_config.stat.exists
+  when:
+    - not (is_docker_build | default(false))
+    - system_distribution_config.stat.exists
   no_log: true
 
 
@@ -20,6 +23,7 @@
     - "{{ ansible_facts.user_dir }}/.config"
     - "{{ ansible_facts.user_dir }}/.config/1password"
     - "{{ ansible_facts.user_dir }}/.config/1password/ssh"
+  when: not (is_docker_build | default(false))
 
 - name: "1PASSWORD | Update file /usr/share/applications/1password.desktop"
   become: true
@@ -29,11 +33,12 @@
     mode: '0755'
     remote_src: true
     force: true
+  when: not (is_docker_build | default(false))
 
 - name: "1PASSWORD | Create symbolic link for 1password/ssh/agent.toml"
-  # become: yes
   ansible.builtin.file:
     src: "{{ role_path }}/files/agent.toml"
     dest: "{{ ansible_facts.user_dir }}/.config/1Password/ssh/agent.toml"
     state: link
     force: yes
+  when: not (is_docker_build | default(false))

--- a/src/roles/docker/tasks/Archlinux.yaml
+++ b/src/roles/docker/tasks/Archlinux.yaml
@@ -1,10 +1,11 @@
 ---
-- name: "DOCKER | Install docker, docker-compose"
+- name: "DOCKER | Install docker, docker-compose, docker-buildx"
   become: true
   community.general.pacman:
     name:
       - docker
       - docker-compose
+      - docker-buildx
     state: present
 
 - name: "LAZYDOCKER | Install"

--- a/src/roles/docker/tasks/main.yaml
+++ b/src/roles/docker/tasks/main.yaml
@@ -16,6 +16,7 @@
     enabled: true
     name: docker
     state: started
+  when: not (is_docker_build | default(false))
 
 - name: "Docker | Add to group"
   become: true

--- a/src/roles/dotfiles/files/alias/env.sh
+++ b/src/roles/dotfiles/files/alias/env.sh
@@ -44,4 +44,4 @@ export FZF_CTRL_T_OPTS="--preview 'bat --color=always --line-range :50 {}'"
 export FZF_ALT_C_COMMAND="fd --type d . --color=never"
 export FZF_ALT_C_OPTS="--preview 'tree -C {} | head -n 50'"
 
-source ~/.config/dotfiles/private-env.sh
+[ -f ~/.config/dotfiles/private-env.sh ] && source ~/.config/dotfiles/private-env.sh

--- a/src/roles/dotfiles/tasks/main.yaml
+++ b/src/roles/dotfiles/tasks/main.yaml
@@ -95,3 +95,4 @@
     enabled: yes
     scope: user
     daemon_reload: yes
+  when: not (is_docker_build | default(false))

--- a/src/roles/system-base/tasks/Archlinux.yaml
+++ b/src/roles/system-base/tasks/Archlinux.yaml
@@ -17,17 +17,26 @@
     - figlet              # write ASCII texts on terminal
     - bc                  # simple calculator CLI
     - sshs                # TUI for SSH (https://github.com/quantumsheep/sshs)
-    - emote               # emoji picker gtk3 (https://github.com/tom-james-watson/Emote)
-    - virt-viewer         # used by SPICE on Proxmox
     - gum                 # "A tool for glamorous shell scripts" (https://github.com/charmbracelet/gum)
-    - gnome-calculator    # default Gnome Calculator
     - zip                 # for compact files
     - unrar               # for compact files
     - "duf"               # Better 'df' alternative
 
+- name: "{{ ansible_facts.distribution }} | Install GUI packages"
+  become: true
+  community.general.pacman:
+    name: "{{ item }}"
+    state: present
+  when: not (is_docker_build | default(false))
+  loop:
+    - emote               # emoji picker gtk3 (https://github.com/tom-james-watson/Emote)
+    - virt-viewer         # used by SPICE on Proxmox
+    - gnome-calculator    # default Gnome Calculator
+
 # Because the tradicional package by `pacman` doesn't work on Wayland.
-- name: "{{ ansible_facts.distribution }} | install AUR packages"
+- name: "{{ ansible_facts.distribution }} | install AUR GUI packages"
   ansible.builtin.shell: "yay -S --needed --noconfirm {{ item }}"
+  when: not (is_docker_build | default(false))
   loop:
     - "flameshot-git"     # Because the tradicional package by `pacman` doesn't work on Wayland.
     - "ddcui"             # GUI to control brightness for external monitors

--- a/src/roles/system-base/tasks/Ubuntu.yaml
+++ b/src/roles/system-base/tasks/Ubuntu.yaml
@@ -29,15 +29,23 @@
     - stow
     - curl
     - wget
-    - meld
     - jq
     - yq
     - ffmpeg
     - imagemagick
-    - xclip
-    - flameshot
     - ncdu
     - figlet
+
+- name: "{{ ansible_facts.distribution }} | Install GUI tools"
+  become: true
+  ansible.builtin.apt:
+    name: "{{ item }}"
+    state: present
+  when: not (is_docker_build | default(false))
+  loop:
+    - meld
+    - xclip
+    - flameshot
     - virt-viewer
 
 # This code block will throw an error inside the Docker container because the container doens't use systemd as the init system.
@@ -92,7 +100,7 @@
         state: restarted
         enabled: yes
       when: keyboard_file_status.changed or keyboard_config_status.changed
-  when: ansible_virtualization_role != "guest" or ansible_virtualization_type != "docker"
+  when: not (is_docker_build | default(false))
 
 - name: "{{ ansible_facts.distribution }} | Enable Dark Mode on Ubuntu"
   ansible.builtin.shell: "gsettings set org.gnome.desktop.interface color-scheme prefer-dark"

--- a/src/roles/tmux/tasks/Archlinux.yaml
+++ b/src/roles/tmux/tasks/Archlinux.yaml
@@ -6,7 +6,6 @@
     state: present
 
 - name: "Tmuxinator | Archlinux | Install tmuxinator"
-  community.general.pacman:
-    name: tmuxinator
-    executable: yay
-    state: present
+  ansible.builtin.shell: "yay -S --needed --noconfirm tmuxinator"
+  args:
+    creates: /usr/bin/tmuxinator

--- a/src/roles/tmux/tasks/systemd.yaml
+++ b/src/roles/tmux/tasks/systemd.yaml
@@ -18,3 +18,4 @@
     enabled: yes
     scope: user
     daemon_reload: yes
+  when: not (is_docker_build | default(false))

--- a/src/roles/zsh/files/.zshrc
+++ b/src/roles/zsh/files/.zshrc
@@ -70,10 +70,12 @@ fi
 #   done
 # fi
 
-# export STARSHIP_CONFIG=~/.config/starship/starship.toml
-# eval "$(starship init zsh)"
+if which starship > /dev/null 2>&1; then
+  export STARSHIP_CONFIG=~/.config/starship/starship.toml
+  eval "$(starship init zsh)"
+fi
 
-. "$HOME/.local/share/../bin/env"
+[ -f "$HOME/.local/bin/env" ] && . "$HOME/.local/bin/env"
 
 export NVM_DIR="$HOME/.config/nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm

--- a/src/roles/zsh/tasks/Archlinux.yaml
+++ b/src/roles/zsh/tasks/Archlinux.yaml
@@ -1,0 +1,6 @@
+---
+- name: "ZSH | Archlinux | Install zsh"
+  become: true
+  community.general.pacman:
+    name: zsh
+    state: present

--- a/src/roles/zsh/tasks/main.yaml
+++ b/src/roles/zsh/tasks/main.yaml
@@ -41,6 +41,12 @@
   loop:
     - { src: "{{ role_path }}/files/.zshrc", dest: "{{ ansible_facts.user_dir }}/.config/zsh/.zshrc" }
 
+- name: "ZSH | Create ~/.zshenv to set ZDOTDIR"
+  ansible.builtin.copy:
+    dest: "{{ ansible_facts.user_dir }}/.zshenv"
+    content: "export ZDOTDIR=$HOME/.config/zsh\n"
+    mode: '0644'
+
 - name: "ZSH | Change to zsh"
   become: yes
   ansible.builtin.shell: "chsh -s $(which zsh) {{ host_user }}"


### PR DESCRIPTION
## Summary

- Adds a personal Docker image (`ghcr.io/frankjuniorr/dotfiles-env`) with the full CLI environment from the dotfiles
- Ansible roles split into `cli_roles` / `gui_roles` — image builds com `--tags cli` e `is_docker_build=true`
- CI/CD pipeline: hadolint lint → build + smoke test → Trivy scan → SBOM (Syft) → cosign signing
- Smoke test com 41 checks cobrindo todas as ferramentas instaladas e symlinks do dotfiles
- Imagem pública no ghcr.io (privada ultrapassaria cota de storage do GitHub Packages)

## What's included

- `Dockerfile` — single-stage em `archlinux:base-devel`, vault password via `--mount=type=secret` (nunca escrito em nenhum layer)
- `docker-compose.yml` — SSH agent forwarding, kubeconfig mount, Docker socket (DooD), `$PWD` como `/workspace`
- `.github/workflows/docker-build.yml` — pipeline CI/CD completo
- `install-env.sh` — script de setup via curl
- `Justfile` — receitas `docker-build`, `docker-smoke`, `docker-up`, `docker-enter`, `docker-clean`
- `scripts/smoke-test.sh` — 41 checks, roda dentro ou fora do container

## Test plan

- [x] Build local funcional (`just docker-build`)
- [x] Smoke test 41/41 passando (`just docker-smoke`)
- [ ] Validar CI/CD completo após merge (push para `main` dispara lint + build + smoke + Trivy)
- [ ] Setar visibilidade do package como **public** no GitHub após primeiro push do CI
- [ ] Tag `v1.2.0` para disparar SBOM e cosign signing

🤖 Generated with [Claude Code](https://claude.com/claude-code)